### PR TITLE
docs: v2.0.0 Next.js 전환 설계 및 DB ERD/삭제 자동화 문서

### DIFF
--- a/docs/2026-07-11-database-erd-and-deletion-automation.md
+++ b/docs/2026-07-11-database-erd-and-deletion-automation.md
@@ -1,0 +1,276 @@
+# v2.0.0 — DB ERD & 글 삭제 자동화 설계 문서 (myblog)
+
+> 이 문서는 [Next.js 전환 설계 문서](./2026-07-11-nextjs-migration-design.md)의 **§2.1 데이터 모델**을 구체화한 하위 설계다.
+
+## Context (왜 이 문서를 만드는가)
+
+Next.js/NestJS 전환(v2.0.0)으로 Supabase Postgres를 **자체 Postgres + Prisma**로 이관한다. 이때
+1. 클라이언트가 직접 다루던 스키마를 서버가 소유하게 되므로 **테이블/관계/제약을 명시적으로 확정**해야 하고,
+2. 자체 인증(JWT)·자체 스토리지(MinIO)를 쓰므로 기존엔 없던 **RefreshToken / 삭제 감사(DeletionLog)** 테이블이 필요하며,
+3. 현재 삭제는 `status=2` 소프트 삭제뿐(영구삭제·이미지 정리 없음)이라, **유예기간 후 자동 영구삭제 + 이미지 정리** 파이프라인을 설계해야 한다.
+
+### 확정 사항
+- 삭제 정책: **소프트삭제(휴지통, 복구 가능) + 유예기간(기본 30일) 경과 후 자동 영구삭제**
+- 자동화 방식: **NestJS `@nestjs/schedule` cron 작업**(앱 내부에서 DB purge + MinIO 이미지 정리)
+- ERD 범위: **현재 기능(User·Profile·Post) + 인증/삭제 자동화용(RefreshToken·DeletionLog)**
+
+---
+
+## 1. ERD (Entity Relationship Diagram)
+
+```mermaid
+erDiagram
+    User ||--o| Profile      : has
+    User ||--o{ Post         : writes
+    User ||--o{ RefreshToken : owns
+    User ||--o{ DeletionLog  : "triggered"
+
+    User {
+        uuid     id         PK
+        string   provider   "github | google"
+        string   providerId
+        string   email      UK "nullable"
+        datetime createdAt
+    }
+    Profile {
+        uuid   userId PK, FK "1:1"
+        string nickName
+        string birth
+        string email
+        string tel
+        string introduce
+        string imageUrl
+    }
+    Post {
+        int      id           PK
+        string   title
+        text     content      "마크다운 원문"
+        int      status       "0=발행 1=임시저장 2=휴지통"
+        uuid     userId       FK
+        datetime createdAt
+        datetime modifiedDate
+        datetime deletedAt    "nullable, status=2 전환 시각"
+    }
+    RefreshToken {
+        uuid     id        PK
+        uuid     userId    FK
+        string   tokenHash UK "해시만 저장"
+        datetime expiresAt
+        datetime createdAt
+        datetime revokedAt "nullable"
+    }
+    DeletionLog {
+        uuid     id            PK
+        int      postId        "스냅샷(FK 아님, 글은 실제 삭제됨)"
+        uuid     userId        FK "nullable, SET NULL"
+        string   titleSnapshot
+        datetime softDeletedAt
+        datetime purgedAt
+        int      imagesDeleted "정리된 이미지 수"
+        string   result        "success | partial | failed"
+    }
+```
+
+### 관계 요약
+- **User 1 : 0..1 Profile** — 사용자당 프로필 1개(`Profile.userId`가 PK 겸 FK).
+- **User 1 : N Post** — 작성자 관계. (개인 블로그이므로 사실상 관리자 1명이지만 스키마는 다중 사용자 대응.)
+- **User 1 : N RefreshToken** — 기기/세션별 refresh 토큰. 회전(rotation) 시 이전 토큰 `revokedAt` 표기.
+- **User 1 : N DeletionLog** — 삭제 자동화 감사 로그. 글은 영구삭제되므로 Post와는 FK를 걸지 않고 `postId`/`titleSnapshot`을 스냅샷으로 보관.
+
+---
+
+## 2. 테이블 상세 & Prisma 스키마
+
+전환 설계 문서 §2.1의 스키마에 **`Post.deletedAt`, `RefreshToken`, `DeletionLog`, `PostStatus` enum, 인덱스/삭제 규칙**을 보강한다.
+
+```prisma
+/// 게시글 상태 (packages/shared 로 공유)
+enum PostStatus {
+  PUBLISHED @map("0")   // 0 — 발행
+  DRAFT     @map("1")   // 1 — 임시저장
+  TRASHED   @map("2")   // 2 — 휴지통(소프트삭제)
+}
+// ↑ 기존 정수값(0/1/2) 그대로 매핑 → 데이터 이관 시 변환 불필요.
+//   Prisma enum 매핑이 부담되면 Int 유지 + shared 상수로 관리해도 됨.
+
+model User {
+  id         String        @id @default(uuid())
+  provider   String        // "github" | "google"
+  providerId String
+  email      String?       @unique
+  createdAt  DateTime      @default(now())
+
+  profile       Profile?
+  posts         Post[]
+  refreshTokens RefreshToken[]
+  deletionLogs  DeletionLog[]
+
+  @@unique([provider, providerId])
+}
+
+model Profile {                       // 기존 userInfo
+  userId    String  @id
+  user      User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  nickName  String?
+  birth     String?
+  email     String?
+  tel       String?
+  introduce String?
+  imageUrl  String?
+}
+
+model Post {
+  id           Int        @id @default(autoincrement())
+  title        String
+  content      String     // 마크다운 원문 (이미지 URL 포함)
+  status       Int        @default(0)   // 0 발행 / 1 임시 / 2 휴지통
+  userId       String
+  author       User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt    DateTime   @default(now())
+  modifiedDate DateTime   @updatedAt
+  deletedAt    DateTime?  // status=2 전환 시각 (유예기간 계산 기준)
+
+  @@index([status, createdAt(sort: Desc)])  // 목록/페이지네이션 (status=0)
+  @@index([status, deletedAt])              // purge 대상 조회 (status=2 & 만료)
+  @@index([userId])
+}
+
+model RefreshToken {
+  id        String    @id @default(uuid())
+  userId    String
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  tokenHash String    @unique          // 원문 토큰이 아닌 해시만 저장
+  expiresAt DateTime
+  createdAt DateTime  @default(now())
+  revokedAt DateTime?                  // 회전/로그아웃 시 무효화
+
+  @@index([userId])
+}
+
+model DeletionLog {
+  id            String   @id @default(uuid())
+  postId        Int                     // 스냅샷 (Post는 실제 삭제되므로 FK 없음)
+  userId        String?
+  user          User?    @relation(fields: [userId], references: [id], onDelete: SetNull)
+  titleSnapshot String
+  softDeletedAt DateTime
+  purgedAt      DateTime @default(now())
+  imagesDeleted Int      @default(0)
+  result        String   @default("success")  // success | partial | failed
+
+  @@index([purgedAt])
+}
+```
+
+### 참조 무결성(ON DELETE) 정리
+| 관계 | 규칙 | 이유 |
+|------|------|------|
+| Profile → User | **CASCADE** | 사용자 삭제 시 프로필 동반 삭제 |
+| Post → User | **CASCADE** | 사용자 삭제 시 글 동반 삭제(개인 블로그). 별도 archive 필요하면 RESTRICT로 변경 |
+| RefreshToken → User | **CASCADE** | 사용자 삭제 시 세션 토큰 제거 |
+| DeletionLog → User | **SET NULL** | 사용자가 사라져도 삭제 감사 기록은 보존 |
+
+---
+
+## 3. 글 삭제 상태 머신 & 자동화 파이프라인
+
+### 3.1 상태 전이
+
+```
+[발행 status=0] ──삭제요청──▶ [휴지통 status=2, deletedAt=now()]
+        ▲                              │
+        │                     ┌────────┴─────────┐
+        └──복구(유예기간 내)──┘        │ (유예기간 경과)
+                                        ▼
+                        [영구삭제: Post row DELETE + MinIO 이미지 제거 + DeletionLog 기록]
+```
+
+- **소프트삭제**: 기존 [components/post/postDelete.js](../components/post/postDelete.js)의 `update status=2` + 소유권 검증([components/crud/checkPostOwner.js](../components/crud/checkPostOwner.js)) 로직을 `PostsService.softDelete()`로 서버 이관. 이때 **`deletedAt=now()`도 함께 기록**(신규).
+- **목록 제외**: 모든 공개 조회는 `WHERE status = 0`. 휴지통 조회(`GET /posts?status=2`)는 소유자 전용.
+- **복구**: `POST /posts/:id/restore` — 유예기간 내 소유자가 `status=0`(또는 이전 상태), `deletedAt=null`로 되돌림.
+- **영구삭제(purge)**: 아래 스케줄러가 수행. 수동 즉시삭제가 필요하면 `DELETE /posts/:id?hard=true`(소유자/관리자) 엔드포인트로 같은 purge 루틴 재사용.
+
+### 3.2 NestJS 스케줄 작업 (`@nestjs/schedule`)
+
+`PostsModule` 내 `PostPurgeService`:
+
+```ts
+@Injectable()
+export class PostPurgeService {
+  private readonly graceDays = Number(process.env.POST_PURGE_GRACE_DAYS ?? 30);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly storage: StorageService,   // MinIO 래퍼 (UploadModule 공유)
+  ) {}
+
+  // 매일 03:00 KST 실행
+  @Cron('0 3 * * *', { timeZone: 'Asia/Seoul' })
+  async purgeExpiredTrash() {
+    const threshold = new Date(Date.now() - this.graceDays * 864e5);
+    const expired = await this.prisma.post.findMany({
+      where: { status: 2, deletedAt: { lt: threshold } },
+      select: { id: true, title: true, content: true, userId: true, deletedAt: true },
+    });
+
+    for (const post of expired) {
+      let imagesDeleted = 0;
+      let result = 'success';
+      try {
+        // 1) 본문 마크다운에서 이미지 URL 추출 후 MinIO 오브젝트 삭제
+        imagesDeleted = await this.storage.deleteByMarkdown(post.content);
+        // 2) DB 행 영구삭제 + 감사 로그를 한 트랜잭션으로
+        await this.prisma.$transaction([
+          this.prisma.post.delete({ where: { id: post.id } }),
+          this.prisma.deletionLog.create({
+            data: {
+              postId: post.id, userId: post.userId,
+              titleSnapshot: post.title, softDeletedAt: post.deletedAt!,
+              imagesDeleted, result: 'success',
+            },
+          }),
+        ]);
+      } catch (e) {
+        result = 'failed';
+        await this.prisma.deletionLog.create({ data: { /* ...실패 기록... */ } });
+        this.logger.error(`purge 실패 postId=${post.id}`, e);
+      }
+    }
+  }
+}
+```
+
+### 3.3 이미지 정리 로직 (MinIO)
+
+`StorageService.deleteByMarkdown(content)`는 발행 시 URL 치환 로직([replacePreviewImagesToUploadedUrls.js](../components/postCreate/inputcontent/replacePreviewImagesToUploadedUrls.js))의 **역방향**이다.
+
+- 정규식 `/!\[[^\]]*\]\((https?:\/\/[^)]+)\)/g`로 본문의 이미지 URL 수집(기존 blob 정규식을 실제 URL용으로 변형).
+- MinIO 공개 URL에서 버킷/오브젝트 키를 파싱 → `removeObjects(bucket, keys)`로 일괄 삭제.
+- **중요**: 삭제 전 다른 글이 같은 오브젝트를 참조하지 않는지 확인(참조 카운팅) 또는 업로드 시 글별 고유 경로(`posts/{postId}/{uuid}.ext`) 규칙을 강제해 공유 위험 제거 — **후자를 권장**(전환 설계 §2.4 업로드 경로 규칙에 반영).
+- 부분 실패는 `DeletionLog.result='partial'`로 남기고 재시도 대상으로 표시.
+
+### 3.4 부가 정리(선택)
+- **고아 이미지(orphan)**: 임시저장 중 업로드됐으나 발행되지 않고 버려진 이미지. 별도 주간 cron으로 `posts/{postId}` 경로 중 어떤 Post에도 참조되지 않는 오브젝트 정리. (초기엔 생략 가능, 리스크로 명시)
+- **만료 RefreshToken 정리**: `revokedAt IS NOT NULL OR expiresAt < now()` 토큰을 같은 스케줄러에서 주기 삭제.
+
+---
+
+## 4. 데이터 이관 시 주의점 (ERD 관점)
+- 기존 `Posts.status` 정수값(0/1/2)을 그대로 적재 → `deletedAt`은 이관 시점에 `status=2`인 글에 한해 세팅. **소급 세팅 시 이관 직후 유예기간이 즉시 만료돼 대량 purge되지 않도록** 첫 실행 전 `deletedAt`을 이관일 기준으로 리셋 권장.
+- 기존 `userInfo` → `Profile` 컬럼 1:1 매핑. Supabase auth user id → 새 `User.id` 매핑 테이블 필요(전환 설계 §5와 동일).
+- `RefreshToken`/`DeletionLog`는 신규 테이블 → 초기 비어 있음.
+
+---
+
+## 5. 검증 방법 (end-to-end)
+- **스키마**: `prisma migrate dev` 성공, 인덱스/제약 생성 확인. `prisma studio`로 관계 확인.
+- **소프트삭제/복구**: 글 삭제 → `status=2 & deletedAt` 세팅 확인, 공개 목록에서 제외 확인, 복구 → `status=0 & deletedAt=null` 확인. 타인 글 삭제 차단(소유권 가드).
+- **자동 purge**: `POST_PURGE_GRACE_DAYS=0`으로 낮춰 `deletedAt`을 과거로 조작한 시드 글에 대해 cron 수동 트리거 → Post 행 삭제 + MinIO 오브젝트 제거 + `DeletionLog` 1건 생성 확인. 트랜잭션 롤백(이미지 삭제 실패 시) 동작 확인.
+- **이미지 정리**: 본문 이미지가 있는 글 purge 후 MinIO에서 해당 키 부재 확인, 타 글이 참조하는 이미지는 보존되는지(고유 경로 규칙) 확인.
+- **RefreshToken**: 로그인 회전 시 이전 토큰 `revokedAt` 세팅, 만료 토큰 정리 확인.
+
+---
+
+## 6. 후속 반영
+- 전환 설계 문서 [§2.1](./2026-07-11-nextjs-migration-design.md)의 Prisma 스키마를 이 문서의 추가분(`deletedAt` / `RefreshToken` / `DeletionLog`)으로 갱신.
+- 전환 설계 §2.4(파일 저장소)에 **글별 고유 이미지 경로(`posts/{postId}/{uuid}.ext`)** 규칙 명시.

--- a/docs/2026-07-11-nextjs-migration-design.md
+++ b/docs/2026-07-11-nextjs-migration-design.md
@@ -1,0 +1,241 @@
+# v2.0.0 — Next.js 전환 설계 문서 (myblog)
+
+## Context (왜 이 작업을 하는가)
+
+현재 `myblog`(릴리즈 v1.4.0)는 **프레임워크 없는 Vanilla JS MPA**다.
+
+- 14개의 정적 HTML 페이지(`pages/*.html`) + `components/*` Vanilla JS 모듈, **Vite** 멀티페이지 번들
+- **Supabase(BaaS)** 를 클라이언트에서 직접 호출: Postgres(`Posts`, `userInfo`), Auth(GitHub/Google OAuth), Storage(이미지), Edge Function(공휴일 프록시)
+- **GitHub Pages** 정적 배포(`dohyuk.dev`)
+
+이 구조의 한계:
+1. **SEO 취약** — 게시글이 CSR로 렌더링돼 크롤러가 본문/제목을 못 읽음. `description`·Open Graph·`canonical`·JSON-LD·sitemap 전무. 게시글별 동적 메타태그 없음.
+2. **서버 렌더링 불가** — 정적 호스팅이라 SSR/ISR을 쓸 수 없음.
+3. **자체 API 계층 부재** — DB 접근 로직이 클라이언트에 노출되고, BaaS(Supabase)에 종속.
+
+### 목표 아키텍처 (확정)
+
+| 영역 | 전환 후 |
+|------|---------|
+| 프론트엔드 | **Next.js 15 App Router + TypeScript + Tailwind v4** (SSR/RSC로 SEO 확보) |
+| 백엔드 | **NestJS** 별도 API 서버 (TypeScript) |
+| DB | **자체 PostgreSQL + Prisma** (Supabase Postgres에서 데이터 이관) |
+| 인증 | **자체 OAuth(GitHub/Google) + JWT** (Supabase Auth 완전 탈피) |
+| 파일 저장 | **자체 오브젝트 스토리지**(S3 호환 MinIO) — Supabase Storage 대체 |
+| 배포 | **자체 Node 서버 / VPS** (Docker Compose + Nginx 리버스 프록시 + TLS) |
+| 방식 | **전면 재작성(Big Bang)** — Supabase/Firebase 완전 제거 |
+
+**설계 원칙**: 클라이언트는 절대 DB에 직접 접근하지 않는다. `Next(웹/BFF) → NestJS(API) → Postgres`. 인증은 NestJS가 JWT를 발급하고 Next는 httpOnly 쿠키로 세션 유지.
+
+---
+
+## 1. 저장소 구조 (pnpm 모노레포)
+
+프론트/백엔드가 **공유 타입(DTO)** 을 쓰므로 pnpm workspace 모노레포로 구성한다.
+
+```
+myblog/                        # 기존 레포를 재구성 (v2 브랜치)
+├─ apps/
+│  ├─ web/                     # Next.js (App Router, TS)
+│  └─ api/                     # NestJS (TS)
+├─ packages/
+│  └─ shared/                  # 공유 타입/상수 (Post 상태 enum 등)
+├─ infra/
+│  ├─ docker-compose.yml       # web, api, postgres, minio, nginx
+│  ├─ nginx/                   # 리버스 프록시 + TLS 설정
+│  └─ Dockerfile.web / Dockerfile.api
+├─ pnpm-workspace.yaml
+└─ turbo.json                  # (선택) Turborepo 태스크 오케스트레이션
+```
+
+> 기존 Vanilla 코드는 `legacy/` 브랜치 또는 태그로 보존하고, `main`은 v2로 교체한다.
+
+---
+
+## 2. 백엔드: NestJS API 서버 (`apps/api`)
+
+### 2.1 데이터 모델 (Prisma)
+
+기존 Supabase 테이블을 자체 Postgres로 이관하고 Prisma 스키마로 모델링. `packages/shared`에 상태 enum을 둔다.
+
+```prisma
+model User {
+  id        String   @id @default(uuid())
+  provider  String   // "github" | "google"
+  providerId String
+  email     String?  @unique
+  profile   Profile?
+  posts     Post[]
+  createdAt DateTime @default(now())
+  @@unique([provider, providerId])
+}
+
+model Profile {          // 기존 userInfo 테이블
+  userId    String  @id
+  user      User    @relation(fields: [userId], references: [id])
+  nickName  String?
+  birth     String?
+  email     String?
+  tel       String?
+  introduce String?
+  imageUrl  String?
+}
+
+model Post {
+  id           Int      @id @default(autoincrement())
+  title        String
+  content      String   // 마크다운 원문
+  status       Int      @default(0)   // 0=발행, 1=임시저장, 2=삭제(soft delete)
+  author       User     @relation(fields: [userId], references: [id])
+  userId       String
+  createdAt    DateTime @default(now())
+  modifiedDate DateTime @updatedAt
+}
+```
+
+> **status 규칙(0/1/2)은 기존 값을 그대로 유지**해 데이터 이관 시 변환을 최소화한다. soft delete(status=2) 정책 유지.
+
+### 2.2 모듈 구성
+
+| 모듈 | 책임 | 주요 엔드포인트 |
+|------|------|-----------------|
+| `AuthModule` | GitHub/Google OAuth(Passport) → JWT(access/refresh) 발급, 검증 가드 | `GET /auth/:provider`, `GET /auth/:provider/callback`, `POST /auth/refresh`, `POST /auth/logout` |
+| `PostsModule` | 게시글 CRUD, 목록+페이지네이션, 소유권 검증, soft delete | `GET /posts` (list, `?page` `?status`), `GET /posts/:id`, `POST /posts`, `PATCH /posts/:id`, `DELETE /posts/:id` |
+| `ProfileModule` | 프로필 조회/upsert | `GET /users/:id/profile`, `PUT /users/me/profile` |
+| `UploadModule` | 이미지 업로드 → MinIO, public URL 반환 | `POST /uploads/post-image`, `POST /uploads/profile-image` |
+| `HolidaysModule` | 공휴일 프록시 (기존 Edge Function 포팅) | `GET /holidays?year=` |
+
+- **인증 가드**: `@UseGuards(JwtAuthGuard)` + 소유권 검사는 기존 `components/crud/checkPostOwner.js` 로직을 `PostsService`에 서버측으로 이관.
+- **페이지네이션**: 기존 `devLog/postUpdate.js`의 `count exact` + `range` 방식을 Prisma `skip/take` + `count`로 재현(10개 단위).
+- **공휴일 포팅**: [supabase/functions/get-holidays/index.ts](../supabase/functions/get-holidays/index.ts)의 `Deno.env.get("HOLIDAY_KEY")` + 공공데이터포털 호출 로직을 그대로 `HolidaysService`로 옮김. CORS는 Nest 전역 설정으로 처리. 응답 캐싱(연 단위) 권장.
+
+### 2.3 인증 흐름 (Supabase Auth 대체)
+
+1. 프론트에서 `GET /api/auth/github` → NestJS가 GitHub OAuth로 리다이렉트
+2. 콜백에서 Nest가 프로필 조회 → `User` upsert → **access JWT(짧게) + refresh JWT(길게)** 발급
+3. Nest가 refresh 토큰을 **httpOnly Secure 쿠키**로 심고 프론트로 리다이렉트
+4. 이후 Next 서버 컴포넌트/미들웨어가 쿠키의 토큰으로 API 호출 시 `Authorization: Bearer` 부착
+5. `POST /auth/refresh`로 access 재발급, `POST /auth/logout`으로 쿠키 무효화
+
+> **OAuth 앱 재등록 필요**: GitHub/Google 개발자 콘솔에서 callback URL을 `https://api.dohyuk.dev/auth/*/callback`로 새로 등록.
+
+### 2.4 파일 저장소 (Supabase Storage 대체)
+
+- **MinIO**(S3 호환) 컨테이너를 self-host. `Post`/`profile` 버킷 대응 버킷 생성.
+- 기존 업로드 최적화 패턴(작성 중 `blob:` 프리뷰 → 발행 시점에만 실제 업로드 후 URL 치환)은 **프론트 로직 유지**, 업로드 대상만 Nest `UploadModule` → MinIO로 변경.
+- `cacheControl: 1년` 헤더 유지. 프로필 이미지는 `{userId}/profile.jpg` upsert 유지.
+
+---
+
+## 3. 프론트엔드: Next.js App Router (`apps/web`)
+
+### 3.1 라우트 매핑 (14 HTML → App Router)
+
+| 기존 HTML | 새 라우트 | 렌더링 | 비고 |
+|-----------|-----------|--------|------|
+| `index.html` | `/` | Static | 랜딩 캔버스 워프 애니메이션 (client component) |
+| `home.html` | `/home` (또는 `/`로 통합) | SSG/ISR | 홈 |
+| `about.html` | `/about` | SSG | 정적 데이터(`components/about/data`) 이식 |
+| `devLog.html` | `/devlog` | **SSR/ISR** | 목록+공휴일, 서버에서 API 호출 |
+| `post.html?id=` | `/posts/[id]` | **SSR + `generateMetadata`** | **SEO 핵심**. 서버에서 본문 렌더 |
+| `postCreate.html` | `/posts/new` | Client (auth) | 마크다운 에디터 |
+| `postCorrection.html` | `/posts/[id]/edit` | Client (auth) | 수정 |
+| `tempPost.html` | `/drafts` | Client (auth) | 임시저장(status=1) 목록 |
+| `profile.html` | `/profile` | Client (auth) | 프로필 |
+| `login.html` | `/login` | Client | OAuth 버튼 |
+| `forgot-password.html` | `/forgot-password` | Static | — |
+| `policy.html` / `terms.html` | `/policy` / `/terms` | Static | — |
+| `404.html` | `not-found.tsx` | — | Next 기본 404 |
+| `header.html` | `components/Header` | — | 공통 레이아웃(`app/layout.tsx`)으로 흡수 |
+
+### 3.2 렌더링 & 데이터 패칭 전략
+
+- **서버 컴포넌트(RSC)** 가 기본. 게시글 상세/목록은 서버에서 NestJS API를 `fetch`(캐시/revalidate 태그 활용)하여 **완성된 HTML을 응답** → 크롤러가 본문을 즉시 읽음.
+- 인터랙션이 필요한 부분(에디터, 다크모드 토글, 캔버스 애니메이션, 드래그)만 `"use client"`.
+- **게시글 상세**: `generateStaticParams` + `revalidate`(ISR)로 인기 글은 정적화, 신규 글은 on-demand revalidate.
+- 보호 라우트(`/posts/new`, `/profile`, `/drafts`)는 `middleware.ts`에서 쿠키 토큰 검사 후 미인증 시 `/login` 리다이렉트.
+
+### 3.3 SEO 구현 (핵심 목표)
+
+- **`generateMetadata`**: `/posts/[id]`에서 게시글 title/description(본문 발췌)/Open Graph/Twitter Card/`canonical` 동적 생성.
+- **동적 OG 이미지**: `opengraph-image.tsx`(next/og)로 게시글 제목 기반 썸네일 자동 생성.
+- **`app/sitemap.ts`**: 발행글(status=0) 목록을 API에서 받아 sitemap 자동 생성.
+- **`app/robots.ts`**: 크롤링 정책 + sitemap 위치.
+- **JSON-LD**: 게시글에 `BlogPosting` 구조화 데이터 삽입.
+- **URL 이전 리다이렉트**: 기존 `/pages/post.html?id=N` → `/posts/N` 301 리다이렉트(`next.config` redirects)로 기존 링크/색인 보존.
+
+### 3.4 기능 이식 (Vanilla → React)
+
+| 기능 | 기존 위치 | 이식 방식 |
+|------|-----------|-----------|
+| 마크다운 렌더 + 자동 TOC | `components/post/postLoad.js` (`marked`) | 서버에서 `marked`로 HTML 변환 + 헤딩 파싱해 TOC 생성(RSC). sanitize 추가 권장 |
+| 블록 마크다운 에디터 | `components/postCreate/*` (`markdown-block-preview`) | ⚠️ **리스크**: 자체 npm 패키지가 Vanilla DOM 기반. React 래퍼로 감싸거나 React용으로 재구현 필요 (§6 참고) |
+| 다크모드 | `components/darkmode/*` (Tailwind `class`) | `next-themes` 또는 클라이언트 컨텍스트로 `class` 전략 유지 |
+| 캔버스 별/워프 애니메이션 | `src/index.js` | client component + `useRef`/`useEffect` |
+| about 인터랙션(카드 드래그 등) | `components/about/*` | client component로 이식 |
+| 폰트(A2Z, xp) | `public/font` + `@font-face` | `next/font/local`로 최적화 로드 |
+| Tailwind v4 | `tailwind.config.js`, `src/style.css` | Next에 Tailwind v4 재설정, typography·line-clamp 플러그인 유지 |
+
+---
+
+## 4. 인프라 & 배포 (자체 Node/VPS)
+
+`infra/docker-compose.yml`로 단일 VPS에 전체 스택 구동:
+
+```
+[ Nginx :443 ]  ── TLS(Let's Encrypt), 리버스 프록시
+   ├─ dohyuk.dev            → web (Next :3000)
+   └─ api.dohyuk.dev        → api (NestJS :4000)
+[ web ]     next start (standalone 빌드)
+[ api ]     NestJS
+[ postgres ] 자체 DB (볼륨 영속화)
+[ minio ]   오브젝트 스토리지 (이미지)
+```
+
+- **Next**: `output: "standalone"`으로 슬림 Docker 이미지.
+- **DNS**: `dohyuk.dev` A레코드를 GitHub Pages → VPS IP로 전환. `api` 서브도메인 추가.
+- **환경변수**: `apps/api/.env`(DB URL, JWT secret, OAuth client id/secret, `HOLIDAY_KEY`, MinIO 키), `apps/web/.env`(API base URL, 공개 사이트 URL). 기존 `.gitignore` 시크릿 위생 규칙([scripts/check-no-tracked-env.sh](../scripts/check-no-tracked-env.sh)) 유지.
+- **CI/CD**: 기존 [.github/workflows/secrets.yml](../.github/workflows/secrets.yml)(gitleaks/env 검사) 유지 + 빌드/타입체크 + VPS 배포(SSH `docker compose pull && up -d` 또는 GHCR 이미지 푸시) 워크플로 추가.
+
+---
+
+## 5. 데이터 이관 (Supabase → 자체 Postgres)
+
+1. Supabase Postgres에서 `Posts`, `userInfo`, auth 사용자 매핑 `pg_dump`/CSV export.
+2. **User 매핑**: Supabase auth user id → 새 `User`(provider/providerId 기준) 매핑 테이블 작성. OAuth 재로그인 시 기존 글과 연결되도록 provider+email 매칭 전략 확정.
+3. `Post.status`(0/1/2) 그대로 적재. `content` 내 **Supabase Storage 이미지 URL을 MinIO URL로 치환**하는 마이그레이션 스크립트 실행.
+4. Storage 버킷의 이미지 파일을 MinIO로 복사.
+5. 이관 검증(건수/무결성) 후 컷오버.
+
+---
+
+## 6. 주요 리스크 & 결정 필요 사항
+
+1. **`markdown-block-preview`(자체 패키지)의 React 호환성** — 가장 큰 불확실성. Vanilla DOM 기반이면 (a) React 래퍼로 감싸기 (b) React용 재구현 (c) 대체 에디터(예: 기존 `marked` + textarea 기반) 중 택. → **초기에 스파이크로 검증 권장.**
+2. **OAuth 재구축 범위** — Passport-github/google 전략 직접 구현 + refresh 토큰 회전 정책 설계 필요(기존엔 Supabase가 대행).
+3. **이미지/스토리지 이관** — MinIO 운영 + 기존 이미지 URL 치환. 대안으로 클라우드 S3/R2도 가능.
+4. **URL 변경에 따른 SEO** — 현재 CSR라 색인이 적어 영향은 작지만, 기존 링크용 301 리다이렉트는 넣어둔다.
+5. **Firebase 제거** — 죽은 코드(`components/login/firebase.js`)이므로 이관 대상 아님, 삭제.
+
+---
+
+## 7. 실행 단계 (마일스톤)
+
+- **M0 — 모노레포 스캐폴드**: pnpm workspace, `apps/web`(Next+TS+Tailwind), `apps/api`(NestJS), `packages/shared`, Docker/Postgres 로컬 기동.
+- **M1 — 백엔드 코어**: Prisma 스키마 + 로컬 DB 마이그레이션, PostsModule(CRUD/목록/soft delete/소유권), ProfileModule, HolidaysModule 포팅.
+- **M2 — 인증**: AuthModule(GitHub/Google OAuth + JWT + 가드), 프론트 로그인/미들웨어 연동.
+- **M3 — 프론트 골격**: `layout.tsx`(공통 헤더/다크모드/폰트), 정적 페이지(about/policy/terms/랜딩), Tailwind 이식.
+- **M4 — 게시글 + SEO**: `/posts/[id]` SSR + `generateMetadata` + JSON-LD + OG 이미지, `/devlog` 목록, sitemap/robots, 301 리다이렉트.
+- **M5 — 에디터 & 업로드**: 마크다운 에디터 이식(리스크 §6-1), UploadModule + MinIO, 이미지 지연 업로드 패턴.
+- **M6 — 데이터 이관**: Supabase → 자체 Postgres/MinIO, 이미지 URL 치환, 검증.
+- **M7 — 인프라 & 컷오버**: docker-compose + Nginx + TLS, DNS 전환, GitHub Pages 폐기, 릴리즈 **v2.0.0** 태깅.
+
+---
+
+## 8. 검증 방법 (end-to-end)
+
+- **백엔드**: `apps/api` — Prisma 마이그레이션 후 각 엔드포인트를 통합 테스트(Jest + supertest)로 검증. 소유권 가드(타인 글 수정/삭제 차단), soft delete(status=2 후 목록 제외), 페이지네이션 경계 확인.
+- **인증**: 실제 GitHub/Google 로그인 → JWT 발급 → 보호 라우트 접근 → refresh → logout 왕복 수동 검증.
+- **SEO(핵심 목표)**: 게시글 페이지를 `curl`로 받아 **본문/제목/`og:`/JSON-LD가 초기 HTML에 포함**되는지 확인(CSR과 대비되는 핵심 성공 기준). `/sitemap.xml`·`/robots.txt` 응답, Lighthouse SEO 점수, 리치 결과 테스트.
+- **기능 패리티**: 글 작성(임시저장→발행)·수정·삭제, 이미지 업로드/치환, 마크다운+TOC 렌더, 다크모드, 공휴일 표시를 기존 사이트와 1:1 비교.
+- **인프라**: docker-compose 로컬 기동 후 Nginx 경유 `dohyuk.dev`/`api.dohyuk.dev` 라우팅, TLS, 재시작 시 DB/이미지 영속성 확인.


### PR DESCRIPTION
## 개요
v2.0.0 Next.js 전환을 위한 설계 문서 2건을 추가합니다.

## 추가 문서
- `docs/2026-07-11-nextjs-migration-design.md` — Next.js(App Router, TS) + NestJS + 자체 Postgres/Prisma + 자체 OAuth/JWT + MinIO + 자체 VPS 배포로의 **전면 재작성** 설계 (모노레포 구조, 라우트 매핑, SEO 전략, 마일스톤 M0~M7, 검증 방법)
- `docs/2026-07-11-database-erd-and-deletion-automation.md` — DB **ERD**(User/Profile/Post/RefreshToken/DeletionLog) 및 참조 무결성, **글 삭제 자동화**(소프트삭제 + 유예기간 후 NestJS 스케줄러 자동 영구삭제 + MinIO 이미지 정리) 설계

## 성격
- 문서만 추가 (코드 변경 없음)
- 실제 구현 착수 전 설계 합의용

🤖 Generated with [Claude Code](https://claude.com/claude-code)