### PR TITLE
docs: markdown-block-preview 패키지의 React 전환 적합성 검토 및 실수요 조사

### DIFF
--- a/docs/2026-07-11-block-rendering-demand-research.md
+++ b/docs/2026-07-11-block-rendering-demand-research.md
@@ -1,0 +1,121 @@
+# 블록 단위 마크다운 증분 렌더링 — 실제 수요 조사
+
+- 작업일: 2026-07-11
+- 관련 문서: [2026-07-11-markdown-preview-perf-review.md](2026-07-11-markdown-preview-perf-review.md)
+- 계기: 위 문서에서 "이 블로그 규모(수백 줄)엔 불필요, 7,000줄급 초장문에서만 의미 있다"는
+  결론을 냈는데, 그렇다면 **실제로 그 정도 규모를 다루는 분야/사용자가 있는지** 별도로 조사
+
+## 요약
+
+있다. 크게 두 갈래로 확인된다.
+
+1. **기존 장문 편집기들이 이미 겪고 있는, 문서화된 문제** — VS Code, Obsidian, Atom, Markdown
+   Monster 모두 "긴 마크다운 문서에서 타이핑/프리뷰가 느려진다"는 이슈를 다수 갖고 있고,
+   구체적인 줄 수 임계치까지 보고돼 있다.
+2. **2026년 현재 가장 활발한 실수요처는 따로 있다 — AI 스트리밍 마크다운 렌더링(챗봇 UI)**.
+   LLM이 토큰 단위로 답변을 스트리밍할 때 매 토큰마다 전체를 재파싱하는 문제를 푸는 것이
+   본질적으로 이 패키지의 "블록 단위, 안정된 부분은 재파싱 안 함" 알고리즘과 동일하다.
+   이 문제를 전용으로 푸는 오픈소스 라이브러리(Incremark, Streamdown 등)가 실제로 존재하고
+   활발히 쓰이고 있다.
+
+즉 "긴 글 에디터"라는 원래 상정했던 시장보다, "AI 채팅 UI의 실시간 마크다운 렌더링"이라는
+시장이 지금은 더 크고 뜨겁다.
+
+---
+
+## 1. 기존 장문 마크다운 편집기의 실측/보고된 성능 문제
+
+| 도구 | 보고된 문제 | 출처 |
+|---|---|---|
+| VS Code (내장) | 마크다운 파일이 10,000줄을 넘으면 성능이 급격히 나빠짐. 초기 프리뷰 렌더에 1~2초, 심하면 거의 1분 | [Issue #301936](https://github.com/microsoft/vscode/issues/301936), [Issue #245841](https://github.com/microsoft/vscode/issues/245841) |
+| VS Code + vscode-markdown 확장 | 813줄짜리 파일에서 프리뷰를 켜놓으면 타이핑한 글자가 화면에 안 보일 정도로 느려짐 | [Issue #323](https://github.com/yzhang-gh/vscode-markdown/issues/323) |
+| Atom `markdown-preview` | 코드 블록이 많은 파일에서 프리뷰가 느려짐(전체 재렌더 방식의 전형적 증상) | [Issue #197](https://github.com/atom/markdown-preview/issues/197) |
+| Markdown Monster | 문서가 2,000줄을 넘으면 프리뷰 갱신이 눈에 띄게 느려지고, 3,000줄을 넘으면 스크롤마다 렉. 대응책으로 "타이핑 멈추고 2초 후에만 리프레시"라는 강제 디바운스를 걸어둠. 10만 단어 이상에서는 아예 자동 동기화를 꺼야 한다고 권장 | [Editing Huge Documents](https://markdownmonster.west-wind.com/docs/FAQ/Editing-Huge-Documents.html) |
+| Obsidian (Live Preview) | 링크/콘텐츠가 많은 노트, 큰 테이블에서 타이핑 시 렉. 키 입력 이벤트 핸들러가 거의 100ms씩 걸리는 사례 보고 | [Poor performance in live preview mode](https://forum.obsidian.md/t/poor-performance-in-live-preview-mode/50136), [Large markdown table causes slowness](https://forum.obsidian.md/t/large-markdown-table-causes-slowness/78593), [UI performance issues with large files](https://forum.obsidian.md/t/ui-performance-issues-with-large-files/13782) |
+
+흥미로운 점: **Markdown Monster 개발자들은 아예 "거대한 단일 마크다운 문서를 만들지 말고
+여러 문서로 쪼개라"고 공식 권고**한다. 즉 업계에서도 "이 정도 규모면 애초에 문서를 나누는 게
+맞다"는 인식이 있다는 뜻이고, 이건 앞선 검토 문서의 "개인 블로그 포스트가 7,000줄까지 갈 일은
+없다"는 판단과 같은 결이다.
+
+이 사례들의 공통된 임계치 감각: **대략 800~3,000줄부터 체감이 시작되고, 10,000줄 이상에서
+심각해진다.** 앞선 실측(600~700블록, 3,000~3,500줄에서 60fps 예산 초과)과 상당히 근접한다.
+
+---
+
+## 2. React 생태계에서도 동일한 문제 — "React면 해결된다"는 아님
+
+가장 널리 쓰이는 React 마크다운 렌더러 `react-markdown`(remarkjs)에도 대형 문서 성능 이슈가
+다수 열려 있다.
+
+- [Discussion #1027](https://github.com/orgs/remarkjs/discussions/1027) — 매우 긴 텍스트에서
+  가상화(virtualization) 없이는 성능이 안 나온다는 논의
+- [Issue #459](https://github.com/remarkjs/react-markdown/issues/459),
+  [Issue #289](https://github.com/remarkjs/react-markdown/issues/289) — 성능 개선 요청
+- [Issue #703](https://github.com/remarkjs/react-markdown/issues/703) — **"React key가 리렌더
+  최적화에 명시적으로 활용되지 않는다"** — 이전 검토 문서에서 "memo만으론 부족하고 key/블록 분리
+  전략이 따로 필요하다"고 분석한 것과 정확히 같은 지적
+- [Issue #621](https://github.com/remarkjs/react-markdown/issues/621) — 작은 문서에서도 렌더에
+  수 ms가 누적된다는 보고
+
+즉 "React를 쓰면 자동으로 빨라진다"는 통념은 실제 생태계에서도 반박되고 있고, 제안되는 해법도
+이전 검토에서 도출한 것과 동일하다: **가상화, `React.memo`, 콘텐츠를 청크로 쪼개기, 필요하면
+Web Worker로 파싱을 메인 스레드 밖으로 빼기.**
+
+---
+
+## 3. 지금 가장 뜨거운 실수요처 — AI 스트리밍 마크다운 렌더링
+
+LLM 챗봇이 답변을 토큰 단위로 스트리밍할 때, 매 토큰마다 지금까지 받은 전체 텍스트를
+처음부터 다시 마크다운 파싱하는 게 업계 표준 구현이었고, 이게 바로 O(n²) 문제였다.
+
+- [From O(n²) to O(n): Building a Streaming Markdown Renderer for the AI Era](https://dev.to/kingshuaishuai/from-on2-to-on-building-a-streaming-markdown-renderer-for-the-ai-era-3k0f) —
+  "답변이 2,000단어에 도달했을 때, 토큰 하나마다 2,000단어를 통째로 재파싱하고 수백 개의 DOM
+  노드를 diff하고 있는 것"이라고 문제를 정의
+- **[Incremark](https://www.incremark.com/)** — "한번 완결된(stable) 블록은 절대 다시 파싱하지
+  않는다"는 불변식으로 O(n²)을 O(n)으로 낮춤. AI 스트리밍 기준 2~10배, 문서가 길수록 더 크게
+  (최대 46배) 개선
+- **[Streamdown](https://streamdown.ai/)** — AI 스트리밍 마크다운 전용 렌더러, Vercel AI SDK
+  생태계에서 실제로 쓰이는 프로덕션 라이브러리
+- **[Vercel AI SDK 공식 쿡북 — "Markdown Chatbot with Memoization"](https://ai-sdk.dev/cookbook/next/markdown-chatbot-with-memoization)** —
+  Next.js/React 공식 예제로 "메모이제이션으로 마크다운 챗봇 성능 개선"을 다룸. 접근 방식이
+  본질적으로 **"블록(문단) 단위로 쪼개고, 완결된 블록은 `memo`로 스킵"** — 이번에 이 세션에서
+  설계한 `splitMarkdownBlocks` + `React.memo` 패턴과 개념적으로 동일
+
+**이 사실이 의미하는 것**: `markdown-block-preview`가 원래 겨냥했던 "긴 글 편집기" 시장은
+실재하지만 상대적으로 니치하다(장문 집필 툴, 위키 등). 반면 **"안정된 블록은 재파싱 안 하고
+변경분만 처리한다"는 동일한 알고리즘이, 지금은 AI 챗봇 UI라는 훨씬 크고 빠르게 성장하는
+시장에서 사실상 표준 해법으로 자리잡고 있다.** 이 패키지의 핵심 아이디어(`splitMarkdownBlocks`
++ 안정/불안정 구분)는 방향 자체는 맞았고, 적용 대상을 "글쓰기 에디터"에서 "AI 응답 스트리밍"
+쪽으로 넓히면 훨씬 수요가 큰 문제를 풀 수 있다.
+
+---
+
+## 4. 이번 블로그 프로젝트에 대한 결론 (변경 없음)
+
+[perf-review 문서](2026-07-11-markdown-preview-perf-review.md)의 결론은 그대로 유효하다 —
+개인 devlog 포스트(수십~수백 줄) 규모에서는 naive 구현(+디바운스)으로 충분하고, 이 알고리즘을
+이식할 필요가 없다. 다만 이번 조사로 다음이 추가로 확인됐다:
+
+- 이 결론은 업계 관행(Markdown Monster의 "문서를 쪼개라" 권고)과도 일치한다.
+- `markdown-block-preview`가 풀려던 문제 자체는 실재하는 문제이며, 폐기할 이유가 없다.
+- 패키지의 다음 방향성을 고민한다면, "긴 글 편집기"보다 **"AI 스트리밍 마크다운 렌더링"** 쪽이
+  훨씬 활발한 실수요가 있는 영역으로 보인다 (참고용, 이번 블로그 마이그레이션 범위 밖).
+
+---
+
+## 참고 자료
+
+- [Editing Huge Documents — Markdown Monster](https://markdownmonster.west-wind.com/docs/FAQ/Editing-Huge-Documents.html)
+- [microsoft/vscode #301936 — Edit markdown file so slow](https://github.com/microsoft/vscode/issues/301936)
+- [microsoft/vscode #245841 — Markdown preview is slow](https://github.com/microsoft/vscode/issues/245841)
+- [yzhang-gh/vscode-markdown #323 — Slow to edit large markdown file](https://github.com/yzhang-gh/vscode-markdown/issues/323)
+- [atom/markdown-preview #197](https://github.com/atom/markdown-preview/issues/197)
+- [Obsidian Forum — Poor performance in live preview mode](https://forum.obsidian.md/t/poor-performance-in-live-preview-mode/50136)
+- [Obsidian Forum — Large markdown table causes slowness](https://forum.obsidian.md/t/large-markdown-table-causes-slowness/78593)
+- [remarkjs/react-markdown Discussion #1027 — virtualization](https://github.com/orgs/remarkjs/discussions/1027)
+- [remarkjs/react-markdown #703 — React keys unoptimized for re-rendering](https://github.com/remarkjs/react-markdown/issues/703)
+- [From O(n²) to O(n): Building a Streaming Markdown Renderer for the AI Era](https://dev.to/kingshuaishuai/from-on2-to-on-building-a-streaming-markdown-renderer-for-the-ai-era-3k0f)
+- [Incremark](https://www.incremark.com/)
+- [Streamdown](https://streamdown.ai/)
+- [Vercel AI SDK Cookbook — Markdown Chatbot with Memoization](https://ai-sdk.dev/cookbook/next/markdown-chatbot-with-memoization)

--- a/docs/2026-07-11-markdown-preview-perf-review.md
+++ b/docs/2026-07-11-markdown-preview-perf-review.md
@@ -1,0 +1,150 @@
+# markdown-block-preview 패키지의 Next.js 전환 적합성 검토
+
+- 작업일: 2026-07-11
+- 관련 문서: [2026-07-11-nextjs-migration-design.md](2026-07-11-nextjs-migration-design.md) §6 리스크 항목 1
+- 첨부 문서: [2026-07-11-block-rendering-demand-research.md](2026-07-11-block-rendering-demand-research.md) —
+  이 문서의 결론(개인 블로그엔 불필요) 이후, "그럼 이 알고리즘을 실제로 필요로 하는 분야/사용자가
+  있는가"를 별도로 조사한 자료
+- 계기: Next.js 전환 설계 논의 중, 자체 npm 패키지 `markdown-block-preview`(블록 단위 마크다운 프리뷰)를 새 아키텍처에서 어떻게 다룰지 실측을 통해 검토
+
+## 요약
+
+패키지 자체(코드)는 vanilla DOM 조작 기반이라 React/SSR에 그대로 이식 불가능하다는 건 처음부터 명확했다.
+쟁점은 "그럼 이 패키지가 구현한 **블록 단위 증분 렌더링 아이디어**까지 버려도 되는가"였고,
+실측 결과 아이디어 자체는 유효했지만 **이 블로그 글 규모에서는 naive 구현으로도 성능 여유가 충분해
+알고리즘 이식 자체가 불필요**하다는 결론을 냈다. 패키지는 폐기가 아니라 독립 오픈소스로 유지하고,
+이번 프로젝트 의존성에서만 제거한다.
+
+---
+
+## 배경 — 패키지가 하는 일
+
+`setupMarkdownPreview({ textarea, preview, breaks })`를 호출하면:
+
+1. `textarea`의 `input` 이벤트마다 `splitMarkdownBlocks()`로 마크다운을 **빈 줄 기준 블록**으로 분리
+2. 이전 블록 배열과 비교(`syncBlockStructure`) — 블록 개수가 같으면 바뀐 블록만 `innerHTML` 교체,
+   append-only면 마지막 블록만 추가, 그 외 구조 변경이면 전체 재구성
+3. 내부적으로 자체 `marked` 인스턴스로 블록 단위 HTML 변환
+
+README 벤치마크(50블록 기준): 1블록 변경 시 전체 렌더 대비 8.2배, 10블록 변경 시 3.8배 빠름.
+전체 블록이 다 바뀌면 오히려 0.8배(diffing 오버헤드로 소폭 손해).
+
+`core/splitMarkdownBlocks.js`, `core/isAppendOnly.js`는 **순수 함수**(DOM 미사용)이고,
+`core/syncBlockStructure.js`, `render/*.js`는 `preview.appendChild`/`preview.innerHTML=""` 등
+**DOM을 직접 조작**한다.
+
+## 왜 React/Next에 그대로 못 쓰나
+
+- SSR 시점엔 `document`가 없어 `getElementById` 자체가 실패 → `useEffect` 안에 넣어야 함
+- React의 파이버 리컨실리에이션과 패키지가 직접 건드리는 실제 DOM이 충돌할 여지
+- 결국 "패키지를 감싸는 래퍼 코드"가 React로 새로 짜는 것보다 더 복잡해짐
+
+→ 기존 리스크 항목의 선택지 (a) React 래퍼로 감싸기는 기각.
+
+## 실측 1 — 파싱 비용 vs DOM 반영 비용 분리 (jsdom)
+
+50블록 문서, 500회 반복 기준:
+
+| 항목 | 평균 |
+|---|---|
+| 전체 문서 파싱(marked) | 0.98ms |
+| 블록 1개만 파싱 | 0.005ms |
+| 전체 innerHTML 반영(50블록) | 13.45ms |
+| 블록 1개만 innerHTML 반영 | 0.18ms |
+| 실제 패키지 end-to-end(1블록 변경) | 0.10ms |
+| React naive 시뮬레이션(매번 전체 파싱+전체 반영) | 10.19ms |
+
+**병목은 마크다운 재파싱이 아니라 DOM 트리 재구성 쪽**이었다. 이는 React를 쓴다고 저절로 해결되지 않는다 —
+`dangerouslySetInnerHTML`에 전체 HTML 문자열을 통째로 넣으면 React는 그 문자열 내부를 diff하지 못하고
+바뀔 때마다 통째로 갈아 끼우기 때문(naive 시뮬레이션이 거의 Full render와 동일한 이유).
+
+## React에서 알고리즘을 이식하는 방법
+
+`React.memo` 단독으로는 부족하다 — 부모가 통짜 문자열 하나를 `state`로 들고 있으면 그 문자열은
+한 글자만 쳐도 매번 달라지므로 `memo`가 비교할 대상 자체가 없다.
+
+```tsx
+"use client";
+import { useState, memo, useMemo } from "react";
+import { marked } from "marked";
+import { splitMarkdownBlocks } from "./splitMarkdownBlocks"; // 패키지의 순수함수를 그대로 재사용
+
+const Block = memo(function Block({ markdown }: { markdown: string }) {
+  return <div dangerouslySetInnerHTML={{ __html: marked.parse(markdown) }} />;
+});
+
+export function MarkdownEditor() {
+  const [text, setText] = useState("");
+  const blocks = useMemo(() => splitMarkdownBlocks(text), [text]);
+
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <textarea value={text} onChange={(e) => setText(e.target.value)} />
+      <div>
+        {blocks.map((block, i) => (
+          <Block key={i} markdown={block} />
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+`splitMarkdownBlocks`(순수 함수)만 그대로 가져오면 되고, DOM을 직접 조작하던
+`syncBlockStructure`/`render/*`는 `key` + `memo` 기반 리컨실리에이션으로 대체된다.
+오히려 블록을 중간에 삽입하는 구조 변경 케이스에서는, 원본 패키지가 전체를 갈아엎는 fallback을
+타는 반면 React 버전은 삽입 지점 이후 블록만 리렌더되므로 원본보다 나을 수 있다.
+
+## 실측 2 — 실제 Chromium에서 naive vs block, 블록 수별 (Playwright)
+
+블록 수를 늘려가며 naive 방식(매번 전체 재파싱+전체 반영)의 편집당 비용을 측정(300회 반복):
+
+| 블록 수 | naive 평균 | 60fps 예산(16.6ms) |
+|---|---|---|
+| 100 | 2.4ms | 여유 |
+| 300 | 7.2ms | 여유 |
+| 500 | 13.3ms | 여유 |
+| 600 | 16.0ms | 경계 |
+| **700** | **20.7ms** | **초과** |
+| 1000 | 30.9ms | 초과 |
+| 1200 | 52.4ms | 초과 |
+
+block 방식(블록 1개만 파싱+반영)은 블록 수와 무관하게 편집당 0.03~0.07ms로 일정.
+
+**약 600~700블록(≈ 마크다운 3,000~3,500줄) 지점**부터 naive 방식이 60fps 프레임 예산을 넘기 시작한다.
+(데스크톱 Chromium 기준. 저사양 모바일은 2~4배 느릴 수 있음 — 감안해도 개인 블로그 포스트가
+이 규모에 도달하는 경우는 사실상 없다.)
+
+## 실측 3 — 극단적 케이스: 실제 패키지 코드로 ~7,000줄(1,400블록) 실측
+
+실제 `markdown-block-preview` 소스(`setupMarkdownPreview`)를 그대로 브라우저에 올려서
+(import map으로 로컬 정적 서버 경유) 8,399줄(1,400블록) 문서로 naive와 직접 비교(200회 반복):
+
+| | npm 패키지 | naive |
+|---|---|---|
+| 초기 렌더 | 100.5ms | 38.1ms |
+| 편집 1회당 비용 | **1.11ms** | 55.09ms (p95 72.7ms) |
+
+의외로 **초기 렌더는 npm 패키지 쪽이 더 느렸다**(블록마다 `createElement`로 노드를 하나씩 만들어
+붙이는 비용이, 브라우저 내장 파서에 큰 HTML 문자열 하나를 통째로 넘기는 것보다 큼). 다만 이건
+에디터를 열 때 한 번만 발생하는 비용이다. 반면 **편집(타이핑) 비용은 패키지가 naive 대비
+49.5배 빠르고**, naive는 키 입력마다 55ms(프레임 예산의 3배)로 실제 렉이 체감되는 반면 패키지는
+1.1ms로 완전히 매끄럽다. 즉 이 알고리즘이 존재 가치를 발휘하는 지점은 정확히 "수천 줄 이상을
+실시간 편집"하는 시나리오다 — 이게 실제로 어떤 분야에 해당하는지는
+[별첨 조사](2026-07-11-block-rendering-demand-research.md) 참고.
+
+## 결론 / 의사결정
+
+- **naive 구현(+필요시 가벼운 input debounce)으로 충분**하다고 판단. block+memo 기반 재구현은
+  이 프로젝트 글 규모(수십~수백 줄)에서는 오버엔지니어링으로 보고 채택하지 않는다.
+- `markdown-block-preview` npm 패키지는 **폐기가 아니라 "이번 프로젝트 요구사항(SSR/React)과
+  안 맞아서 안 쓰는 것"** — 독립 오픈소스 패키지로는 그대로 유지, vanilla JS 프로젝트에서는 여전히 유효.
+- 이번 마이그레이션에서는 `apps/web`의 `package.json`에서 해당 의존성만 제거한다.
+- 이 알고리즘을 실제로 필요로 하는 분야가 있는지는 [별첨 문서](2026-07-11-block-rendering-demand-research.md)에서 따로 조사했다.
+
+## 남은 일 (이번 세션 범위 밖)
+
+- 설계 문서 §6-1 리스크 항목 문구 자체를 "결정됨(naive+debounce 채택, 알고리즘 이식 안 함)"으로
+  갱신할지는 별도 확인 필요.
+- `marked` 렌더링 결과에 sanitize(XSS 방지, 예: DOMPurify) 처리가 없다는 기존 한계는 이번 검토
+  범위 밖이며 여전히 미해결.

--- a/docs/2026-07-11-nextjs-migration-design.md
+++ b/docs/2026-07-11-nextjs-migration-design.md
@@ -6,7 +6,7 @@
 
 - 14개의 정적 HTML 페이지(`pages/*.html`) + `components/*` Vanilla JS 모듈, **Vite** 멀티페이지 번들
 - **Supabase(BaaS)** 를 클라이언트에서 직접 호출: Postgres(`Posts`, `userInfo`), Auth(GitHub/Google OAuth), Storage(이미지), Edge Function(공휴일 프록시)
-- **GitHub Pages** 정적 배포(`dohyuk.dev`)
+- **Vercel** 정적 배포(`dohyuk.dev`)
 
 이 구조의 한계:
 1. **SEO 취약** — 게시글이 CSR로 렌더링돼 크롤러가 본문/제목을 못 읽음. `description`·Open Graph·`canonical`·JSON-LD·sitemap 전무. 게시글별 동적 메타태그 없음.
@@ -17,7 +17,7 @@
 
 | 영역 | 전환 후 |
 |------|---------|
-| 프론트엔드 | **Next.js 15 App Router + TypeScript + Tailwind v4** (SSR/RSC로 SEO 확보) |
+| 프론트엔드 | **Next.js 16 App Router + TypeScript + Tailwind v4** (SSR/RSC로 SEO 확보) |
 | 백엔드 | **NestJS** 별도 API 서버 (TypeScript) |
 | DB | **자체 PostgreSQL + Prisma** (Supabase Postgres에서 데이터 이관) |
 | 인증 | **자체 OAuth(GitHub/Google) + JWT** (Supabase Auth 완전 탈피) |
@@ -193,7 +193,7 @@ model Post {
 ```
 
 - **Next**: `output: "standalone"`으로 슬림 Docker 이미지.
-- **DNS**: `dohyuk.dev` A레코드를 GitHub Pages → VPS IP로 전환. `api` 서브도메인 추가.
+- **DNS**: `dohyuk.dev` A레코드를 Vercel → VPS IP로 전환. `api` 서브도메인 추가.
 - **환경변수**: `apps/api/.env`(DB URL, JWT secret, OAuth client id/secret, `HOLIDAY_KEY`, MinIO 키), `apps/web/.env`(API base URL, 공개 사이트 URL). 기존 `.gitignore` 시크릿 위생 규칙([scripts/check-no-tracked-env.sh](../scripts/check-no-tracked-env.sh)) 유지.
 - **CI/CD**: 기존 [.github/workflows/secrets.yml](../.github/workflows/secrets.yml)(gitleaks/env 검사) 유지 + 빌드/타입체크 + VPS 배포(SSH `docker compose pull && up -d` 또는 GHCR 이미지 푸시) 워크플로 추가.
 
@@ -228,7 +228,7 @@ model Post {
 - **M4 — 게시글 + SEO**: `/posts/[id]` SSR + `generateMetadata` + JSON-LD + OG 이미지, `/devlog` 목록, sitemap/robots, 301 리다이렉트.
 - **M5 — 에디터 & 업로드**: 마크다운 에디터 이식(리스크 §6-1), UploadModule + MinIO, 이미지 지연 업로드 패턴.
 - **M6 — 데이터 이관**: Supabase → 자체 Postgres/MinIO, 이미지 URL 치환, 검증.
-- **M7 — 인프라 & 컷오버**: docker-compose + Nginx + TLS, DNS 전환, GitHub Pages 폐기, 릴리즈 **v2.0.0** 태깅.
+- **M7 — 인프라 & 컷오버**: docker-compose + Nginx + TLS, DNS 전환, Vercel 배포 폐기, 릴리즈 **v2.0.0** 태깅.
 
 ---
 


### PR DESCRIPTION
- 블록 단위 증분 렌더링 알고리즘의 성능을 jsdom/실제 Chromium으로 실측
- React 이식 시 필요한 것(splitMarkdownBlocks 재사용 + memo/key)과 불필요한 것(DOM 직접 조작 코드)을 구분
- 이 블로그 규모에서는 naive 구현으로 충분하다는 결론과, 실제로 이 알고리즘이 필요한 분야(장문 에디터, AI 스트리밍 마크다운 렌더링)를 별도 조사해 첨부